### PR TITLE
Fix Azure Deploy dev ACA environment resolution

### DIFF
--- a/.github/workflows/azd-deploy.yml
+++ b/.github/workflows/azd-deploy.yml
@@ -227,7 +227,7 @@ jobs:
       ACA_ENVIRONMENT_NAME: ${{ needs.resolve-release.outputs.aca_environment_name }}
       AZURE_LOCATION: ${{ needs.resolve-release.outputs.azure_location }}
       TF_VAR_environment: ${{ needs.resolve-release.outputs.azure_env_name }}
-      TF_VAR_existing_container_app_environment_name: ${{ needs.resolve-release.outputs.aca_environment_name }}
+      TF_VAR_existing_container_app_environment_name: ${{ needs.resolve-release.outputs.release_tier == 'prod' && needs.resolve-release.outputs.aca_environment_name || '' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary\n- stop forcing TF_VAR_existing_container_app_environment_name in non-prod\n- keep explicit existing ACA env only for prod deployments\n\n## Why\nDev runs failed when 	utor-dev-acae was absent because Terraform data lookup was forced instead of allowing environment-driven creation/resolution.