### PR TITLE
Fix Terraform ACA environment resolution for dev/prod

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,5 +1,7 @@
 locals {
   normalized_prefix = lower(replace("${var.name_prefix}${var.environment}", "-", ""))
+  container_app_environment_name = var.existing_container_app_environment_name != "" ? var.existing_container_app_environment_name : "${var.name_prefix}-${var.environment}-acae"
+  container_app_environment_id   = var.existing_container_app_environment_name != "" ? data.azurerm_container_app_environment.main[0].id : azurerm_container_app_environment.main[0].id
   backend_service_names = [
     "avatar",
     "configuration",
@@ -149,8 +151,18 @@ resource "azurerm_private_dns_zone_virtual_network_link" "cosmos" {
 }
 
 data "azurerm_container_app_environment" "main" {
-  name                = var.existing_container_app_environment_name != "" ? var.existing_container_app_environment_name : "${var.name_prefix}-${var.environment}-acae"
+  count               = var.existing_container_app_environment_name != "" ? 1 : 0
+  name                = local.container_app_environment_name
   resource_group_name = azurerm_resource_group.main.name
+}
+
+resource "azurerm_container_app_environment" "main" {
+  count                      = var.existing_container_app_environment_name == "" ? 1 : 0
+  name                       = local.container_app_environment_name
+  location                   = azurerm_resource_group.main.location
+  resource_group_name        = azurerm_resource_group.main.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+  infrastructure_subnet_id   = var.aca_vnet_integration_enabled ? azurerm_subnet.aca_infrastructure[0].id : null
 }
 
 resource "azurerm_container_registry" "main" {
@@ -259,7 +271,7 @@ resource "azurerm_container_app" "backend_services" {
   for_each = toset(local.backend_service_names)
 
   name                         = "${var.name_prefix}-${each.key}-${var.environment}"
-  container_app_environment_id = data.azurerm_container_app_environment.main.id
+  container_app_environment_id = local.container_app_environment_id
   resource_group_name          = azurerm_resource_group.main.name
   revision_mode                = "Single"
 


### PR DESCRIPTION
## Summary\n- add conditional ACA environment data/resource resolution\n- if xisting_container_app_environment_name is set, read existing env\n- if empty, create ACA environment and use its ID\n- wire backend container apps to resolved environment ID via local\n\n## Why\nAzure Deploy (azd) dev runs failed when 	utor-dev-acae did not already exist. This makes provisioning deterministic without cross-environment assumptions.