### PR TITLE
infra: honor dynamic ACA env in tfvars

### DIFF
--- a/infra/terraform/main.tfvars.json
+++ b/infra/terraform/main.tfvars.json
@@ -1,7 +1,7 @@
 {
   "environment": "${AZURE_ENV_NAME}",
   "location": "${AZURE_LOCATION}",
-  "existing_container_app_environment_name": "",
+  "existing_container_app_environment_name": "${TF_VAR_existing_container_app_environment_name}",
   "aca_vnet_integration_enabled": true,
   "cosmos_public_network_access_enabled": false,
   "cosmos_lockout_acknowledged": true


### PR DESCRIPTION
## Summary\n- replace hardcoded empty xisting_container_app_environment_name in infra/terraform/main.tfvars.json with ${TF_VAR_existing_container_app_environment_name}\n\n## Root Cause\nWorkflow step Resolve ACA environment ownership mode correctly detected 	utor-dev-acae and exported TF_VAR_existing_container_app_environment_name, but zd passes main.tfvars.json to Terraform and that file hardcoded the field to empty string.\n\n## Effect\nTerraform always planned zurerm_container_app_environment.main[0] creation and failed with lready exists ... needs to be imported.\n\n## Validation\n- Confirmed from run 22997362488 logs that env var was set but apply still attempted ACA create.\n