### PR TITLE
Fix ACA bootstrap provisioning timeouts in Terraform

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -290,18 +290,6 @@ resource "azurerm_container_app" "backend_services" {
       image  = "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"
       cpu    = 0.5
       memory = "1Gi"
-
-      liveness_probe {
-        path      = "/health"
-        port      = 8000
-        transport = "HTTP"
-      }
-
-      readiness_probe {
-        path      = "/ready"
-        port      = 8000
-        transport = "HTTP"
-      }
     }
   }
 


### PR DESCRIPTION
## Root cause\nTerraform foundation creates Container Apps with a placeholder image, but bootstrap liveness/readiness probes target /health and /ready on port 8000. The placeholder image does not satisfy those checks, causing ContainerAppOperationError and Operation expired during zd provision.\n\n## Permanent fix\n- remove bootstrap liveness/readiness probes from zurerm_container_app.backend_services in infra/terraform/main.tf\n- keep runtime health enforcement in workflow guardrails after real service images are deployed\n\n## Validation\n- 	erraform -chdir=infra/terraform validate succeeds\n- failure signature in run 22998945689 matches probe-driven revision timeout path