### PR TITLE
Fix ACA env not-found in Terraform plan

### DIFF
--- a/.github/workflows/azd-deploy.yml
+++ b/.github/workflows/azd-deploy.yml
@@ -228,6 +228,7 @@ jobs:
       AZURE_LOCATION: ${{ needs.resolve-release.outputs.azure_location }}
       TF_VAR_environment: ${{ needs.resolve-release.outputs.azure_env_name }}
       TF_VAR_existing_container_app_environment_name: ${{ needs.resolve-release.outputs.release_tier == 'prod' && needs.resolve-release.outputs.aca_environment_name || '' }}
+      TF_VAR_reuse_existing_container_app_environment: ${{ needs.resolve-release.outputs.release_tier == 'prod' && 'true' || 'false' }}
 
     steps:
       - name: Checkout
@@ -330,7 +331,9 @@ jobs:
             if [ "$aca_state" = "Succeeded" ]; then
               echo "Detected healthy ACA environment ${ACA_NAME}; Terraform will reference it."
               echo "TF_VAR_existing_container_app_environment_name=${ACA_NAME}" >> "$GITHUB_ENV"
+              echo "TF_VAR_reuse_existing_container_app_environment=true" >> "$GITHUB_ENV"
               azd env set TF_VAR_existing_container_app_environment_name "$ACA_NAME"
+              azd env set TF_VAR_reuse_existing_container_app_environment "true"
             else
               echo "Detected ACA environment ${ACA_NAME} with provisioningState='${aca_state:-unknown}'."
               echo "Deleting failed/unhealthy ACA environment so Terraform can recreate it cleanly."
@@ -356,12 +359,16 @@ jobs:
               fi
 
               echo "TF_VAR_existing_container_app_environment_name=" >> "$GITHUB_ENV"
+              echo "TF_VAR_reuse_existing_container_app_environment=false" >> "$GITHUB_ENV"
               azd env set TF_VAR_existing_container_app_environment_name ""
+              azd env set TF_VAR_reuse_existing_container_app_environment "false"
             fi
           else
             echo "No existing ACA environment detected; Terraform will create managed environment ${ACA_NAME}."
             echo "TF_VAR_existing_container_app_environment_name=" >> "$GITHUB_ENV"
+            echo "TF_VAR_reuse_existing_container_app_environment=false" >> "$GITHUB_ENV"
             azd env set TF_VAR_existing_container_app_environment_name ""
+            azd env set TF_VAR_reuse_existing_container_app_environment "false"
           fi
 
       - name: Refresh Azure Login after ACA reconciliation

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,7 +1,7 @@
 locals {
   normalized_prefix = lower(replace("${var.name_prefix}${var.environment}", "-", ""))
   container_app_environment_name = var.existing_container_app_environment_name != "" ? var.existing_container_app_environment_name : "${var.name_prefix}-${var.environment}-acae"
-  container_app_environment_id   = var.existing_container_app_environment_name != "" ? data.azurerm_container_app_environment.main[0].id : azurerm_container_app_environment.main[0].id
+  container_app_environment_id   = var.reuse_existing_container_app_environment ? data.azurerm_container_app_environment.main[0].id : azurerm_container_app_environment.main[0].id
   backend_service_names = [
     "avatar",
     "configuration",
@@ -151,13 +151,13 @@ resource "azurerm_private_dns_zone_virtual_network_link" "cosmos" {
 }
 
 data "azurerm_container_app_environment" "main" {
-  count               = var.existing_container_app_environment_name != "" ? 1 : 0
+  count               = var.reuse_existing_container_app_environment ? 1 : 0
   name                = local.container_app_environment_name
   resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_container_app_environment" "main" {
-  count                      = var.existing_container_app_environment_name == "" ? 1 : 0
+  count                      = var.reuse_existing_container_app_environment ? 0 : 1
   name                       = local.container_app_environment_name
   location                   = azurerm_resource_group.main.location
   resource_group_name        = azurerm_resource_group.main.name

--- a/infra/terraform/main.tfvars.json
+++ b/infra/terraform/main.tfvars.json
@@ -2,6 +2,7 @@
   "environment": "${AZURE_ENV_NAME}",
   "location": "${AZURE_LOCATION}",
   "existing_container_app_environment_name": "${TF_VAR_existing_container_app_environment_name}",
+  "reuse_existing_container_app_environment": ${TF_VAR_reuse_existing_container_app_environment},
   "aca_vnet_integration_enabled": true,
   "cosmos_public_network_access_enabled": false,
   "cosmos_lockout_acknowledged": true

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -171,6 +171,12 @@ variable "existing_container_app_environment_name" {
   default     = ""
 }
 
+variable "reuse_existing_container_app_environment" {
+  description = "Whether Terraform should reuse an existing Container Apps Environment instead of creating one."
+  type        = bool
+  default     = false
+}
+
 variable "aca_vnet_integration_enabled" {
   description = "Whether the ACA environment is integrated with a VNet that can privately reach Cosmos DB."
   type        = bool


### PR DESCRIPTION
## Root cause\nTerraform treated xisting_container_app_environment_name as sufficient to read a data source. When the name was present but the environment did not exist (or had been removed), plan failed with \Managed Environment ... was not found\.\n\n## Permanent fix\n- add explicit boolean \euse_existing_container_app_environment\ in Terraform\n- use boolean (not just string presence) to switch between data-source reuse and resource creation\n- wire boolean through \main.tfvars.json\ as a JSON boolean\n- update workflow ACA ownership reconciliation to set both variables deterministically based on actual Azure state\n\n## Validation\n- \	erraform -chdir=infra/terraform init -backend=false\\n- \	erraform -chdir=infra/terraform validate\\n\n## Expected effect\nDev no longer fails with data lookup errors when \	utor-dev-acae\ is absent; Terraform will create a managed environment unless reuse is explicitly true and confirmed by workflow detection.