### PR TITLE
Fix ACA indeterminate-state fallback in Azure Deploy

### DIFF
--- a/.github/workflows/azd-deploy.yml
+++ b/.github/workflows/azd-deploy.yml
@@ -346,8 +346,12 @@ jobs:
               aca_state="$(timeout 45s az containerapp env show --resource-group "$RG_NAME" --name "$ACA_NAME" --query 'provisioningState' -o tsv 2>/dev/null || true)"
             fi
             if [ -z "$aca_state" ] || [ "$aca_state" = "null" ]; then
-              echo "Unable to resolve provisioning state for ${ACA_NAME}; defaulting to reuse existing environment."
-              aca_state="Succeeded"
+              echo "Unable to resolve provisioning state for ${ACA_NAME}; defaulting to Terraform-managed creation mode."
+              echo "TF_VAR_existing_container_app_environment_name=" >> "$GITHUB_ENV"
+              echo "TF_VAR_reuse_existing_container_app_environment=false" >> "$GITHUB_ENV"
+              azd env set TF_VAR_existing_container_app_environment_name ""
+              azd env set TF_VAR_reuse_existing_container_app_environment "false"
+              exit 0
             fi
 
             if [ "$aca_state" = "Succeeded" ]; then


### PR DESCRIPTION
## Root cause\nWhen ACA exists check succeeded but provisioningState could not be resolved, workflow fallback set reuse mode. This could still drive Terraform into data-source lookups and fail with Managed Environment ... was not found.\n\n## Permanent fix\nFor indeterminate ACA state, force Terraform-managed creation mode (euse=false, empty existing name) instead of reuse.\n\n## Expected effect\nEliminates false-positive reuse and removes recurring not-found data-source plan failures.