### PR TITLE
Prevent concurrent Azure Deploy state collisions

### DIFF
--- a/.github/workflows/azd-deploy.yml
+++ b/.github/workflows/azd-deploy.yml
@@ -24,7 +24,7 @@ on:
 
 concurrency:
   group: azd-deploy-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   id-token: write


### PR DESCRIPTION
Root cause: concurrent main deploy runs wrote the same Terraform backend state. Fix: set workflow concurrency cancel-in-progress to true for the same ref.