### PR TITLE
ci: restrict ACA reuse mode to prod only

### DIFF
--- a/.github/workflows/azd-deploy.yml
+++ b/.github/workflows/azd-deploy.yml
@@ -342,6 +342,15 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ "$RELEASE_TIER" != "prod" ]; then
+            echo "Non-prod release tier detected; keeping Terraform-managed ACA mode."
+            echo "TF_VAR_existing_container_app_environment_name=" >> "$GITHUB_ENV"
+            echo "TF_VAR_reuse_existing_container_app_environment=false" >> "$GITHUB_ENV"
+            azd env set TF_VAR_existing_container_app_environment_name ""
+            azd env set TF_VAR_reuse_existing_container_app_environment "false"
+            exit 0
+          fi
+
           RG_NAME="tutor-${AZURE_ENV_NAME}"
           ACA_NAME="tutor-${AZURE_ENV_NAME}-acae"
 


### PR DESCRIPTION
## Summary
- keep ACA ownership reconciliation in Terraform-managed mode for non-prod releases
- only evaluate/use existing ACA environment reuse for prod releases

## Root cause
In dev, the workflow switched TF vars to reuse-existing mode after detecting a healthy ACA environment. Terraform then attempted to destroy the managed environment and failed with ManagedEnvironmentHasContainerApps.

## Outcome
Dev deployments remain in stable Terraform-managed mode and stop planning ACA environment destruction.
