### PR TITLE
P1: Upgrade GitHub Actions dependencies for Node 24 runtime

### DIFF
--- a/.github/workflows/azd-deploy.yml
+++ b/.github/workflows/azd-deploy.yml
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -234,7 +234,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
@@ -243,7 +243,7 @@ jobs:
         uses: Azure/setup-azd@v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 
@@ -1031,7 +1031,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
@@ -1107,7 +1107,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
@@ -1170,7 +1170,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Azure Developer CLI
         uses: Azure/setup-azd@v2

--- a/.github/workflows/azure-static-web-apps-polite-wave-029b18f0f.yml
+++ b/.github/workflows/azure-static-web-apps-polite-wave-029b18f0f.yml
@@ -32,12 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Frontend PR Checks
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
           lfs: false
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
       - name: Set up pnpm
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Prod
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
           lfs: false
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
           lfs: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`


### PR DESCRIPTION
Closes #89

## Summary
Low-risk Node 24 readiness update for GitHub workflows:
- ctions/checkout upgraded 4 -> v5
- ctions/setup-node upgraded 4 -> v5

## Scope
- .github/workflows/azd-deploy.yml
- .github/workflows/azure-static-web-apps-polite-wave-029b18f0f.yml
- .github/workflows/codeql.yml

## Notes
Kept Azure-specific setup actions unchanged in this step (zure/login@v2, Azure/setup-azd@v2, hashicorp/setup-terraform@v3) to avoid unverified major-version jumps.
