### PR TITLE
fix(ci): correct ACA quarantine artifact upload path

### DIFF
--- a/.github/workflows/azd-deploy.yml
+++ b/.github/workflows/azd-deploy.yml
@@ -674,7 +674,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: aca-quarantine-${{ needs.resolve-release.outputs.azure_env_name }}-${{ github.run_id }}
-          path: aca-quarantine/
+          path: infra/terraform/aca-quarantine/
           retention-days: 14
           if-no-files-found: warn
 


### PR DESCRIPTION
## Summary\n- fix quarantine diagnostics upload path in zd-deploy.yml\n- upload from infra/terraform/aca-quarantine/, matching where reconcile writes files\n\n## Why\nLatest deployment incident run captured quarantine state but artifact collection depended on the upload path being correct for deterministic triage.\n\n## Validation\n- workflow YAML lint in editor: no errors\n- change is path-only (1 line)\n\nRelated: #86