### PR TITLE
Harden deployment OIDC environment scopes

### DIFF
--- a/.github/workflows/aca-recovery.yml
+++ b/.github/workflows/aca-recovery.yml
@@ -22,13 +22,16 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
   recover:
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    permissions:
+      id-token: write
+      contents: read
+    environment: ${{ github.event.inputs.environment }}
     env:
       AZURE_ENV_NAME: ${{ github.event.inputs.environment }}
       SERVICES_CSV: ${{ github.event.inputs.services }}

--- a/.github/workflows/azd-deploy.yml
+++ b/.github/workflows/azd-deploy.yml
@@ -31,7 +31,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -250,10 +249,14 @@ jobs:
   provision-foundation:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      id-token: write
+      contents: read
     needs:
       - resolve-release
       - detect-changes
     if: needs.detect-changes.outputs.provision_required == 'true'
+    environment: ${{ needs.resolve-release.outputs.release_tier }}
 
     env:
       RELEASE_TIER: ${{ needs.resolve-release.outputs.release_tier }}
@@ -1123,12 +1126,16 @@ jobs:
 
   provision-service-infra:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     needs:
       - resolve-release
       - detect-changes
       - provision-foundation
       - deploy-backend-services
     if: always() && needs.detect-changes.outputs.service_infra_count != '0' && (needs.detect-changes.outputs.provision_required != 'true' || needs.provision-foundation.result == 'success') && needs.deploy-backend-services.result == 'success'
+    environment: ${{ needs.resolve-release.outputs.release_tier }}
     strategy:
       fail-fast: false
       matrix:
@@ -1410,11 +1417,15 @@ jobs:
 
   deploy-backend-services:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     needs:
       - resolve-release
       - detect-changes
       - provision-foundation
     if: always() && needs.detect-changes.outputs.service_count != '0' && (needs.detect-changes.outputs.provision_required != 'true' || needs.provision-foundation.result == 'success')
+    environment: ${{ needs.resolve-release.outputs.release_tier }}
     strategy:
       fail-fast: false
       matrix:
@@ -2187,12 +2198,16 @@ jobs:
 
   post-deploy-guardrails:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     needs:
       - resolve-release
       - detect-changes
       - deploy-backend-services
       - provision-service-infra
     if: always() && needs.detect-changes.outputs.service_count != '0' && needs.deploy-backend-services.result == 'success' && (needs.provision-service-infra.result == 'success' || needs.provision-service-infra.result == 'skipped')
+    environment: ${{ needs.resolve-release.outputs.release_tier }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/azure-static-web-apps-polite-wave-029b18f0f.yml
+++ b/.github/workflows/azure-static-web-apps-polite-wave-029b18f0f.yml
@@ -32,9 +32,7 @@ on:
       - ".github/workflows/azure-static-web-apps-polite-wave-029b18f0f.yml"
 
 permissions:
-  id-token: write
   contents: read
-  pull-requests: write
 
 jobs:
   resolve-release:
@@ -129,7 +127,11 @@ jobs:
   resolve-azure-endpoints:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     needs: resolve-release
+    environment: ${{ needs.resolve-release.outputs.release_tier }}
     outputs:
       apim_base_url: ${{ steps.resolve_apim.outputs.apim_base_url }}
     env:
@@ -188,10 +190,14 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tier == 'prod' && startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, 'stable')) ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tier == 'auto' && startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, 'stable'))
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     needs:
       - resolve-release
       - resolve-azure-endpoints
     name: Build and Deploy Prod
+    environment: prod
     env:
       SWA_NAME: ${{ needs.resolve-release.outputs.swa_name }}
       RESOURCE_GROUP: ${{ needs.resolve-release.outputs.resource_group }}
@@ -236,10 +242,14 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tier == 'dev') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.release_tier == 'auto' && (!startsWith(github.ref, 'refs/tags/') || !contains(github.ref_name, 'stable')))
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     needs:
       - resolve-release
       - resolve-azure-endpoints
     name: Build and Deploy Dev
+    environment: dev
     env:
       SWA_NAME: ${{ needs.resolve-release.outputs.swa_name }}
       RESOURCE_GROUP: ${{ needs.resolve-release.outputs.resource_group }}
@@ -279,10 +289,15 @@ jobs:
           output_location: ""
 
   close_pull_request:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.base_ref == 'main'
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.base_ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
     needs: resolve-release
     name: Close Pull Request
+    environment: dev
     env:
       SWA_NAME: ${{ needs.resolve-release.outputs.swa_name }}
       RESOURCE_GROUP: ${{ needs.resolve-release.outputs.resource_group }}


### PR DESCRIPTION
## Summary
- Scope Azure OIDC deployment jobs to GitHub environments.
- Move `id-token: write` from workflow-wide defaults to Azure-authenticated jobs.
- Add a same-repository guard before closing Static Web Apps PR previews.

## Deployment path
- Target dev deployment variable will be set to `109dev`, producing Azure resources under the existing `tutor-109dev` naming pattern.
- After this PR passes required checks and merges into `main`, the authorized `main` push workflows will redeploy through GitHub Actions.

## Validation
- YAML parse passed for edited workflows.
- CRLF-aware `git diff --check` passed for edited workflows.