### PR TITLE
Trigger deployment on azd workflow changes

### DIFF
--- a/.github/workflows/azd-deploy.yml
+++ b/.github/workflows/azd-deploy.yml
@@ -192,7 +192,10 @@ jobs:
                   selected_service_infra=("${all_services[@]}")
                   ;;
                 .github/workflows/azd-deploy.yml)
-                  echo "Workflow-only change detected. Skipping full infrastructure reprovision trigger."
+                  echo "Deployment workflow change detected. Triggering full deployment validation."
+                  provision_required=true
+                  selected_services=("${all_services[@]}")
+                  selected_service_infra=("${all_services[@]}")
                   ;;
                 lib/*)
                   selected_services=("${all_services[@]}")


### PR DESCRIPTION
## Summary
- Make changes to `.github/workflows/azd-deploy.yml` trigger full foundation and backend deployment validation on `main` pushes.
- This keeps the tutor109 redeploy on the PR -> gates -> merge -> `main` push path instead of using direct deployment.

## Deployment target
- Repo variable `AZURE_ENV_NAME` is set to `109dev`.
- The resulting Azure resource group target is `tutor-109dev`.

## Validation
- YAML parse passed for `.github/workflows/azd-deploy.yml`.
- CRLF-aware `git diff --check` passed.