### PR TITLE
Use deployment region for Foundry quota

### DIFF
--- a/.github/workflows/azd-deploy.yml
+++ b/.github/workflows/azd-deploy.yml
@@ -268,6 +268,8 @@ jobs:
       ACA_ENVIRONMENT_NAME: ${{ needs.resolve-release.outputs.aca_environment_name }}
       AZURE_LOCATION: ${{ needs.resolve-release.outputs.azure_location }}
       TF_VAR_environment: ${{ needs.resolve-release.outputs.azure_env_name }}
+      TF_VAR_location: ${{ needs.resolve-release.outputs.azure_location }}
+      TF_VAR_foundry_location: ${{ needs.resolve-release.outputs.azure_location }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Pass `TF_VAR_location` and `TF_VAR_foundry_location` from the resolved deployment region.
- This moves the Tutor 109 dev AI Foundry deployment to `eastus2`, where `gpt-5-nano` and `gpt-5` quota is available.
- Avoids changing or deleting unrelated westus3 deployments that currently consume the quota.

## Deployment target
- Repo variable `AZURE_ENV_NAME` remains `109dev`.
- Target resource group remains `tutor-109dev`.

## Validation
- YAML parse passed for `.github/workflows/azd-deploy.yml`.
- CRLF-aware `git diff --check` passed.