### PR TITLE
Include Foundry account in preseed target

### DIFF
--- a/.github/workflows/azd-deploy.yml
+++ b/.github/workflows/azd-deploy.yml
@@ -815,6 +815,7 @@ jobs:
 
           echo "Pre-seeding first model deployment to serialize Cognitive Services operations..."
           terraform apply -auto-approve -parallelism=4 \
+            -target='module.ai_foundry.azapi_resource.ai_foundry' \
             -target='module.ai_foundry.azapi_resource.ai_model_deployment["gpt-5-nano"]'
 
           echo "Pre-seed complete. Full provision will create the remaining model."


### PR DESCRIPTION
## Summary
- Include the AI Foundry account resource in the targeted pre-seed Terraform apply.
- This lets Terraform reconcile the parent account location before creating `gpt-5-nano`, which is needed after the failed westus3 partial apply.

## Deployment target
- Repo variable `AZURE_ENV_NAME` remains `109dev`.
- Target resource group remains `tutor-109dev`.
- Foundry target region is `eastus2`, where GPT-5 quota is available.

## Validation
- YAML parse passed for `.github/workflows/azd-deploy.yml`.
- CRLF-aware `git diff --check` passed.