### PR TITLE
Decouple AI Foundry account suffix

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -71,6 +71,12 @@ resource "random_string" "suffix" {
   special = false
 }
 
+resource "random_string" "ai_foundry_suffix" {
+  length  = 6
+  upper   = false
+  special = false
+}
+
 resource "azurerm_resource_group" "main" {
   name     = "${var.name_prefix}-${var.environment}"
   location = var.location
@@ -390,7 +396,7 @@ module "ai_foundry" {
   resource_group_resource_id = azurerm_resource_group.main.id
 
   ai_foundry = {
-    name                    = "${local.normalized_prefix}${random_string.suffix.result}ai"
+    name                    = "${local.normalized_prefix}${random_string.ai_foundry_suffix.result}ai"
     create_ai_agent_service = true
     disable_local_auth      = false
   }


### PR DESCRIPTION
## Summary
- add a dedicated Terraform random suffix for the AI Foundry account name
- keep the shared environment suffix for non-Foundry resources
- avoid blocked Cognitive Services custom subdomains from soft-deleted Foundry accounts

## Validation
- terraform fmt -check infra/terraform/main.tf
- terraform -chdir=infra/terraform validate

## Context
The latest main deployment reached eastus2 but failed with Azure 409 CustomDomainInUse for the soft-deleted Foundry/Cognitive Services subdomain tutor109devi1rv80ai. This keeps the redeploy on the PR/gates/main-trigger path without purging deleted Azure resources.