### PR TITLE
Fix Foundry RBAC role assignment

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -89,7 +89,7 @@ Set `agent_principal_object_ids` with managed identity object IDs for additional
 - `Cosmos DB Built-in Data Contributor` (native Cosmos SQL role assignments at account and database scope)
 - `Storage Blob Data Contributor`
 - `AcrPull`
-- `Cognitive Services User`
+- `Foundry User`
 
 Example:
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -50,7 +50,7 @@ locals {
   agent_role_scopes = {
     "Storage Blob Data Contributor" = azurerm_storage_account.uploads.id
     "AcrPull"                       = azurerm_container_registry.main.id
-    "Azure AI User"                 = module.ai_foundry.ai_foundry_id
+    "Foundry User"                  = module.ai_foundry.ai_foundry_id
   }
 
   agent_role_assignments = {
@@ -531,13 +531,13 @@ resource "azurerm_api_management_api_policy" "backend_services_hardening" {
 resource "azurerm_role_assignment" "container_app_cognitive_services" {
   for_each             = toset(local.backend_service_names)
   scope                = module.ai_foundry.ai_foundry_id
-  role_definition_name = "Azure AI User"
+  role_definition_name = "Foundry User"
   principal_id         = azurerm_container_app.backend_services[each.key].identity[0].principal_id
 }
 
 resource "azurerm_role_assignment" "foundry_project_ai_user" {
   scope                = module.ai_foundry.ai_foundry_id
-  role_definition_name = "Azure AI User"
+  role_definition_name = "Foundry User"
   principal_id         = module.ai_foundry.ai_foundry_project_system_identity_principal_id["tutor"]
 }
 


### PR DESCRIPTION
main deployment run 26204365056 failed because Azure role `Azure AI User` does not exist; this replaces it with built-in `Foundry User` and aligns Terraform README; validation passed locally (`terraform fmt -check infra/terraform/main.tf`, `terraform -chdir=infra/terraform validate`).