### PR TITLE
Fix APIM fallback CORS policy

### DIFF
--- a/.github/workflows/azd-deploy.yml
+++ b/.github/workflows/azd-deploy.yml
@@ -1382,7 +1382,53 @@ jobs:
               fi
             done
 
-            policy_payload="$(ORIGINS_JSON="$TF_VAR_allowed_origins" python -c 'import json, os; origins=json.loads(os.environ["ORIGINS_JSON"]); origin_xml="".join(f"        <origin>{origin}</origin>\\n" for origin in origins); xml=("<policies>\\n" "  <inbound>\\n" "    <base />\\n" "    <cors allow-credentials=\"false\">\\n" "      <allowed-origins>\\n" "        <origin>http://localhost:3000</origin>\\n" "        <origin>http://localhost:5173</origin>\\n" f"{origin_xml}" "      </allowed-origins>\\n" "      <allowed-methods preflight-result-max-age=\"86400\">\\n" "        <method>*</method>\\n" "      </allowed-methods>\\n" "      <allowed-headers>\\n" "        <header>*</header>\\n" "      </allowed-headers>\\n" "    </cors>\\n" "  </inbound>\\n" "  <backend>\\n" "    <base />\\n" "  </backend>\\n" "  <outbound>\\n" "    <base />\\n" "  </outbound>\\n" "  <on-error>\\n" "    <base />\\n" "  </on-error>\\n" "</policies>"); print(json.dumps({"properties": {"format": "rawxml", "value": xml}}))')"
+            policy_payload="$(ORIGINS_JSON="$TF_VAR_allowed_origins" python - <<'PY'
+          import json
+          import os
+          from xml.sax.saxutils import escape
+
+          required_origins = [
+            origin
+            for origin in json.loads(os.environ["ORIGINS_JSON"])
+            if origin
+          ]
+          origins = [
+            "http://localhost:3000",
+            "http://localhost:5173",
+            *required_origins,
+          ]
+          cors_xml = (
+            '<cors allow-credentials="false">'
+            '<allowed-origins>'
+            + "".join(f"<origin>{escape(origin)}</origin>" for origin in origins)
+            + '</allowed-origins>'
+            '<allowed-methods preflight-result-max-age="86400"><method>*</method></allowed-methods>'
+            '<allowed-headers><header>*</header></allowed-headers>'
+            '</cors>'
+          )
+          xml = "\n".join(
+            [
+              "<policies>",
+              "  <inbound>",
+              "    <base />",
+              f"    {cors_xml}",
+              "  </inbound>",
+              "  <backend>",
+              "    <base />",
+              "  </backend>",
+              "  <outbound>",
+              "    <base />",
+              "  </outbound>",
+              "  <on-error>",
+              "    <base />",
+              "  </on-error>",
+              "</policies>",
+            ]
+          ) + "\n"
+
+          print(json.dumps({"properties": {"format": "rawxml", "value": xml}}))
+          PY
+            )"
             az rest \
               --method put \
               --uri "https://management.azure.com/subscriptions/${ARM_SUBSCRIPTION_ID}/resourceGroups/${RG}/providers/Microsoft.ApiManagement/service/${APIM_NAME}/apis/${API_ID}/policies/policy?api-version=2022-08-01" \
@@ -2435,28 +2481,27 @@ jobs:
             for origin in json.loads(os.environ.get("REQUIRED_CORS_ORIGINS_JSON", "[]"))
             if origin
           ]
-          origin_lines = [
-            "            <origin>http://localhost:3000</origin>",
-            "            <origin>http://localhost:5173</origin>",
-            *[f"            <origin>{escape(origin)}</origin>" for origin in required_origins],
+          origins = [
+            "http://localhost:3000",
+            "http://localhost:5173",
+            *required_origins,
           ]
+          cors_xml = (
+            '<cors allow-credentials="false">'
+            '<allowed-origins>'
+            + "".join(f"<origin>{escape(origin)}</origin>" for origin in origins)
+            + '</allowed-origins>'
+            '<allowed-methods preflight-result-max-age="86400"><method>*</method></allowed-methods>'
+            '<allowed-headers><header>*</header></allowed-headers>'
+            '</cors>'
+          )
 
           xml = "\n".join(
             [
               "<policies>",
               "  <inbound>",
               "    <base />",
-              "    <cors allow-credentials=\"false\">",
-              "      <allowed-origins>",
-              *origin_lines,
-              "      </allowed-origins>",
-              "      <allowed-methods preflight-result-max-age=\"86400\">",
-              "        <method>*</method>",
-              "      </allowed-methods>",
-              "      <allowed-headers>",
-              "        <header>*</header>",
-              "      </allowed-headers>",
-              "    </cors>",
+              f"    {cors_xml}",
               "  </inbound>",
               "  <backend>",
               "    <base />",


### PR DESCRIPTION
Run 26205283318 failed all provision-service-infra jobs because Terraform backend fallback APIM policy remediation generated a CORS policy APIM rejected.

This fix emits compact escaped CORS XML in both fallback and post-deploy remediation paths.

Validation passed locally:
- YAML parse for .github/workflows/azd-deploy.yml
- Compiled and executed the embedded Python heredoc snippets without touching Azure