### PR TITLE
Enable dev pilot auth headers

### DIFF
--- a/.github/workflows/azure-static-web-apps-polite-wave-029b18f0f.yml
+++ b/.github/workflows/azure-static-web-apps-polite-wave-029b18f0f.yml
@@ -280,6 +280,7 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         env:
           NEXT_PUBLIC_APIM_BASE_URL: ${{ needs.resolve-azure-endpoints.outputs.apim_base_url }}
+          NEXT_PUBLIC_PILOT_AUTH_HEADERS_ENABLED: "true"
         with:
           azure_static_web_apps_api_token: ${{ steps.swa_token.outputs.api_token }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -23,6 +23,8 @@ const LOCAL_DEVELOPMENT_HEADERS = {
   "X-Feature-Flags": "workspace-shell,workspace-snapshots,learner-record-preview",
 } as const;
 
+const PILOT_AUTH_HEADERS_ENABLED = process.env.NEXT_PUBLIC_PILOT_AUTH_HEADERS_ENABLED === "true";
+
 const LOCAL_HOST_PATTERN = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|::1)$/i;
 
 const normalizeBaseURL = (value: string | undefined): string | undefined => {
@@ -120,7 +122,7 @@ const createClient = (
       }
     }
 
-    if (isLocalLikeUrl(config.baseURL) || isLocalLikeUrl(config.url)) {
+    if (PILOT_AUTH_HEADERS_ENABLED || isLocalLikeUrl(config.baseURL) || isLocalLikeUrl(config.url)) {
       applyLegacyLocalHeaders(config);
     }
 


### PR DESCRIPTION
## Summary
- add a build-time frontend flag for pilot auth headers
- enable the flag only in the dev Static Web Apps workflow
- keep production SWA builds on the normal APIM-only path

## Validation
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint

## Notes
This fixes the dev workspace 401 on /api/configuration/access-context without weakening backend auth middleware.