### PR TITLE
Declare aiohttp for shared Cosmos client

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pydantic-settings>=2.4.0",
     "PyJWT[crypto]>=2.10.1",
     "azure-cosmos>=4.10.0",
+    "aiohttp>=3.13.3",
     "azure-identity>=1.21.0",
     "azure-servicebus>=7.14.2",
     "azure-ai-projects>=2.0.0",


### PR DESCRIPTION
- Adds aiohttp to tutor-lib runtime deps because shared Cosmos async CRUD imports azure.cosmos.aio
- Fixes live insights learner-records 500 `aiohttp package is not installed`
- Verification: wheel metadata includes aiohttp, CosmosCRUD/aiohttp import check, `python -m pytest tests\lib -q` (30 passed)